### PR TITLE
Null check in IO.close

### DIFF
--- a/src/ox/IO.java
+++ b/src/ox/IO.java
@@ -129,7 +129,9 @@ public class IO {
 
   public static void close(Closeable c) {
     try {
-      c.close();
+      if (c != null) {
+        c.close();
+      }
     } catch (IOException e) {
       throw propagate(e);
     }


### PR DESCRIPTION
This would be used to close resources in the finally blocks where the closable may not be initialized