### PR TITLE
Add utility functions for min, f-string and TimeWrapper

### DIFF
--- a/src/ox/util/Functions.java
+++ b/src/ox/util/Functions.java
@@ -139,6 +139,11 @@ public final class Functions {
     return ret;
   }
 
+  @SafeVarargs
+  public static <T extends Comparable<? super T>> T min(T... values) {
+    return min(values);
+  }
+
   public static <T extends Comparable<? super T>> T min(Iterable<T> iter) {
     T ret = null;
     for (T t : iter) {

--- a/src/ox/util/Time.java
+++ b/src/ox/util/Time.java
@@ -22,6 +22,7 @@ public class Time {
   public static final ZoneId CENTRAL = ZoneId.of("US/Central");
   public static final ZoneId NEW_YORK = ZoneId.of("America/New_York");
   public static ZoneId DEFAULT_TIME_ZONE = PACIFIC_TIME;
+  public static TimeWrapper timeWrapper = new TimeWrapper();
 
   public static final DateTimeFormatter slashFormat = DateTimeFormatter.ofPattern("MM/dd/yyyy");
   private static final DateTimeFormatter longFormat = DateTimeFormatter.ofPattern("MMM d, yyyy");
@@ -58,7 +59,7 @@ public class Time {
   }
 
   public static LocalDate now() {
-    return LocalDate.now(DEFAULT_TIME_ZONE);
+    return timeWrapper.now();
   }
 
   public static int daysSince(long timestamp) {
@@ -158,6 +159,12 @@ public class Time {
 
   public static void setDefaultTimeZone(ZoneId zone) {
     Time.DEFAULT_TIME_ZONE = checkNotNull(zone);
+  }
+
+  public static class TimeWrapper {
+    public LocalDate now() {
+      return LocalDate.now(DEFAULT_TIME_ZONE);
+    }
   }
 
 }

--- a/src/ox/util/Utils.java
+++ b/src/ox/util/Utils.java
@@ -16,6 +16,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.security.SecureRandom;
 import java.text.DecimalFormat;
+import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Base64;
@@ -92,6 +93,10 @@ public class Utils {
   }
 
   private static final String[] units = new String[] { "B", "KB", "MB", "GB", "TB" };
+
+  public static String f(String format, Object... args) {
+    return MessageFormat.format(format, args);
+  }
 
   public static String formatBytes(long size) {
     if (size <= 0) {


### PR DESCRIPTION
The `f` method mirror's Python's f-strings which is a handy shorthand for formatting strings.

TimeWrapper allows time.now() to be easily mocked in unit tests. Test cases for verifying calculations based on the usage of time.now need to use a frozen value of now for more predictable testing. 