### PR TITLE
Remove checkstate for rows all having same size in csv reader.

### DIFF
--- a/src/ox/util/CSVReader.java
+++ b/src/ox/util/CSVReader.java
@@ -1,6 +1,5 @@
 package ox.util;
 
-import static com.google.common.base.Preconditions.checkState;
 import static ox.util.Utils.propagate;
 
 import java.io.BufferedReader;
@@ -153,10 +152,8 @@ public class CSVReader {
 
     if (lastSize == 0) {
       lastSize = ret.size();
-    } else {
-      checkState(ret.size() == lastSize, "Found a row with " + ret.size() +
-          " elements when we previously saw a row with " + lastSize + " elements.");
     }
+
     return ret;
   }
 


### PR DESCRIPTION
@mirraj2 if this is bad please let me know how this checkState was supposed to be helping.  