### PR TITLE
Automatically set content type to "application/json" on sending json request

### DIFF
--- a/src/ox/HttpRequest.java
+++ b/src/ox/HttpRequest.java
@@ -1401,7 +1401,8 @@ public class HttpRequest {
   }
 
   public HttpRequest send(Json json) {
-    return send(json.toString());
+    return contentType(CONTENT_TYPE_JSON, CHARSET_UTF8)
+        .send(json.toString());
   }
 
   public HttpRequest send(final byte[] input) throws HttpRequestException {


### PR DESCRIPTION
Description
Add the contentType(CONTENT_TYPE_JSON, CHARSET_UTF8) to send(json) method. This can avoid an occasional issue that some servers cannot correctly decode json content with non-ascii contents.

Test
check the request content with netcat locally.


`POST / HTTP/1.1
Content-Type: application/json; charset=UTF-8
User-Agent: Java/11.0.16
Host: 127.0.0.1:8080
Accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2
Connection: keep-alive
...`