### PR TITLE
escape double quotes

### DIFF
--- a/src/ox/util/CSVWriter.java
+++ b/src/ox/util/CSVWriter.java
@@ -28,8 +28,8 @@ public class CSVWriter {
     int size = row.size();
     for (Object o : row) {
       if (o != null) {
-        String s = o.toString();
-        if (s.indexOf(',') != -1 || s.indexOf('\n') != -1 || s.indexOf('"') != -1) {
+        String s = o.toString().replaceAll("\"", "\"\"");
+        if (s.indexOf(',') != -1 || s.indexOf('\n') != -1) {
           buffer.append('"');
           buffer.append(s);
           buffer.append('"');

--- a/src/ox/util/CSVWriter.java
+++ b/src/ox/util/CSVWriter.java
@@ -29,7 +29,7 @@ public class CSVWriter {
     for (Object o : row) {
       if (o != null) {
         String s = o.toString().replaceAll("\"", "\"\"");
-        if (s.indexOf(',') != -1 || s.indexOf('\n') != -1) {
+        if (s.indexOf(',') != -1 || s.indexOf('\n') != -1 || s.indexOf('"') != -1) {
           buffer.append('"');
           buffer.append(s);
           buffer.append('"');

--- a/src/ox/util/CSVWriter.java
+++ b/src/ox/util/CSVWriter.java
@@ -28,7 +28,7 @@ public class CSVWriter {
     int size = row.size();
     for (Object o : row) {
       if (o != null) {
-        String s = o.toString().replaceAll("\"", "\"\"");
+        String s = o.toString().replace("\"", "\"\"");
         if (s.indexOf(',') != -1 || s.indexOf('\n') != -1 || s.indexOf('"') != -1) {
           buffer.append('"');
           buffer.append(s);


### PR DESCRIPTION
Failing to escape the double quotes in a string can break the writing of a string to the csv. This bug came up because a user entered a single " in a string. Seems most reliable to escape them.