### PR TITLE
Escape double quotes in writer and reader, update tests

### DIFF
--- a/src/ox/util/CSVReader.java
+++ b/src/ox/util/CSVReader.java
@@ -177,7 +177,8 @@ public class CSVReader {
       char c = line.charAt(i);
       if (c == escape) {
         if (escaped) {
-          // next character must be a delimiter in order to unescape (or we've reached end of file)
+          // next character must be a delimiter in order to unescape (or we've reached end
+          // of file)
           if (i == line.length() - 1 || line.charAt(i + 1) == delimiter) {
             escaped = false;
           } else {
@@ -187,7 +188,7 @@ public class CSVReader {
           escaped = true;
         }
       } else if (!escaped && c == delimiter) {
-        ret.add(sb.toString());
+        ret.add(sb.toString().replace("\"\"", "\""));
         sb.setLength(0);
       } else {
         sb.append(c);
@@ -204,7 +205,7 @@ public class CSVReader {
         }
       }
     }
-    ret.add(sb.toString());
+    ret.add(sb.toString().replace("\"\"", "\""));
     sb.setLength(0);
 
     if (lastSize == 0) {
@@ -270,7 +271,8 @@ public class CSVReader {
     }
 
     /**
-     * Get date assuming it is stored as an "Excel" date, which is a number of days since the Excel epoch date.
+     * Get date assuming it is stored as an "Excel" date, which is a number of days
+     * since the Excel epoch date.
      */
     public LocalDate getExcelDate(String colName) {
       String val = get(colName);

--- a/src/ox/util/CSVWriter.java
+++ b/src/ox/util/CSVWriter.java
@@ -28,7 +28,7 @@ public class CSVWriter {
     int size = row.size();
     for (Object o : row) {
       if (o != null) {
-        String s = o.toString();
+        String s = o.toString().replace("\"", "\"\"");
         if (s.indexOf(',') != -1 || s.indexOf('\n') != -1 || s.indexOf('"') != -1) {
           buffer.append('"');
           buffer.append(s);

--- a/test/ox/util/CSVTest.java
+++ b/test/ox/util/CSVTest.java
@@ -1,6 +1,7 @@
 package ox.util;
 
 import static com.google.common.base.Preconditions.checkState;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -10,6 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 import ox.IO;
+import ox.Log;
 import ox.x.XList;
 
 public class CSVTest {
@@ -18,6 +20,21 @@ public class CSVTest {
   public void test() {
     XList<String> input = XList.of("a", "b", "c", "this is a \"quoted\" word");
 
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    CSVWriter writer = new CSVWriter(baos);
+    writer.write(input);
+    writer.close();
+
+    CSVReader reader = new CSVReader(new ByteArrayInputStream(baos.toByteArray()));
+    XList<String> output = reader.nextLine();
+
+    checkState(input.equals(output), input + " vs " + output);
+
+  }
+
+  @Test
+  public void jakeAndJZTest() {
+    XList<String> input = XList.of("a", "A \"on\" B, C\nD", "z");
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     CSVWriter writer = new CSVWriter(baos);
     writer.write(input);

--- a/test/ox/util/CSVTest.java
+++ b/test/ox/util/CSVTest.java
@@ -1,7 +1,6 @@
 package ox.util;
 
 import static com.google.common.base.Preconditions.checkState;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -11,7 +10,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 import ox.IO;
-import ox.Log;
 import ox.x.XList;
 
 public class CSVTest {


### PR DESCRIPTION
[CSV Standard for escaping double quotes](https://www.rfc-editor.org/rfc/rfc4180#page-2)
See #7:
```
 7.  If double-quotes are used to enclose fields, then a double-quote
       appearing inside a field must be escaped by preceding it with
       another double quote.  For example:

       "aaa","b""bb","ccc"
```
This PR is escaping double quotes with another double quote on write, and then does the opposite escaping (removing 2 double quotes) on read. Fixed the broken test from last time, and additionally added a test that mimic'd the string that was breaking the csv format